### PR TITLE
breaking: remove IshapeDrawer from IShape.Draw(), instead add it to shape constructor.

### DIFF
--- a/BattleStars.Tests/Core/BattleStarTest.cs
+++ b/BattleStars.Tests/Core/BattleStarTest.cs
@@ -11,7 +11,6 @@ namespace BattleStars.Tests.Core;
 public class TestBattleStarFixture
 {
     public Mock<IShape> MockShape = new();
-    public Mock<IShapeDrawer> MockShapeDrawer = new();
     public Mock<IMovable> MockMovable = new();
     public Mock<IDestructable> MockDestructable = new();
     public Mock<IShooter> MockShooter = new();
@@ -21,7 +20,6 @@ public class TestBattleStarFixture
     {
         BattleStar = new BattleStar(
             MockShape.Object,
-            MockShapeDrawer.Object,
             MockMovable.Object,
             MockDestructable.Object,
             MockShooter.Object);
@@ -63,28 +61,11 @@ public class BattleStarTest : IClassFixture<TestBattleStarFixture>
     {
         // Arrange
         IShape nullShape = null!;
-        var mockShapeDrawer = new Mock<IShapeDrawer>();
         var mockMovable = new Mock<IMovable>();
         var mockDestructable = new Mock<IDestructable>();
         var mockShooter = new Mock<IShooter>();
 
-        Action act = () => new BattleStar(nullShape, mockShapeDrawer.Object, mockMovable.Object, mockDestructable.Object, mockShooter.Object);
-
-        // Act & Assert
-        act.Should().Throw<ArgumentNullException>();
-    }
-
-    [Fact]
-    public void GivenNullShapeDrawer_WhenConstructed_ThenThrowsArgumentNullException()
-    {
-        // Arrange
-        var mockShape = new Mock<IShape>();
-        IShapeDrawer nullShapeDrawer = null!;
-        var mockMovable = new Mock<IMovable>();
-        var mockDestructable = new Mock<IDestructable>();
-        var mockShooter = new Mock<IShooter>();
-
-        Action act = () => new BattleStar(mockShape.Object, nullShapeDrawer, mockMovable.Object, mockDestructable.Object, mockShooter.Object);
+        Action act = () => new BattleStar(nullShape, mockMovable.Object, mockDestructable.Object, mockShooter.Object);
 
         // Act & Assert
         act.Should().Throw<ArgumentNullException>();
@@ -95,12 +76,11 @@ public class BattleStarTest : IClassFixture<TestBattleStarFixture>
     {
         // Arrange
         var mockShape = new Mock<IShape>();
-        var mockShapeDrawer = new Mock<IShapeDrawer>();
         IMovable nullMovable = null!;
         var mockDestructable = new Mock<IDestructable>();
         var mockShooter = new Mock<IShooter>();
 
-        Action act = () => new BattleStar(mockShape.Object, mockShapeDrawer.Object, nullMovable, mockDestructable.Object, mockShooter.Object);
+        Action act = () => new BattleStar(mockShape.Object, nullMovable, mockDestructable.Object, mockShooter.Object);
 
         // Act & Assert
         act.Should().Throw<ArgumentNullException>();
@@ -111,12 +91,11 @@ public class BattleStarTest : IClassFixture<TestBattleStarFixture>
     {
         // Arrange
         var mockShape = new Mock<IShape>();
-        var mockShapeDrawer = new Mock<IShapeDrawer>();
         var mockMovable = new Mock<IMovable>();
         IDestructable nullDestructable = null!;
         var mockShooter = new Mock<IShooter>();
 
-        Action act = () => new BattleStar(mockShape.Object, mockShapeDrawer.Object, mockMovable.Object, nullDestructable, mockShooter.Object);
+        Action act = () => new BattleStar(mockShape.Object, mockMovable.Object, nullDestructable, mockShooter.Object);
 
         // Act & Assert
         act.Should().Throw<ArgumentNullException>();
@@ -127,12 +106,12 @@ public class BattleStarTest : IClassFixture<TestBattleStarFixture>
     {
         // Arrange
         var mockShape = new Mock<IShape>();
-        var mockShapeDrawer = new Mock<IShapeDrawer>();
         var mockMovable = new Mock<IMovable>();
         var mockDestructable = new Mock<IDestructable>();
         IShooter nullShooter = null!;
 
-        Action act = () => new BattleStar(mockShape.Object, mockShapeDrawer.Object, mockMovable.Object, mockDestructable.Object, nullShooter);
+        Action act = () => new BattleStar(mockShape.Object, mockMovable.Object, mockDestructable.Object, nullShooter);
+
 
         // Act & Assert
         act.Should().Throw<ArgumentNullException>();
@@ -143,12 +122,11 @@ public class BattleStarTest : IClassFixture<TestBattleStarFixture>
     {
         // Arrange
         var mockShape = new Mock<IShape>();
-        var mockShapeDrawer = new Mock<IShapeDrawer>();
         var mockMovable = new Mock<IMovable>();
         var mockDestructable = new Mock<IDestructable>();
         var mockShooter = new Mock<IShooter>();
 
-        Action act = () => new BattleStar(mockShape.Object, mockShapeDrawer.Object, mockMovable.Object, mockDestructable.Object, mockShooter.Object);
+        Action act = () => new BattleStar(mockShape.Object, mockMovable.Object, mockDestructable.Object, mockShooter.Object);
 
         // Act & Assert
         act.Should().NotThrow();
@@ -170,7 +148,7 @@ public class BattleStarTest : IClassFixture<TestBattleStarFixture>
         battleStar.Draw();
 
         // Assert
-        testBattleStar.MockShape.Verify(s => s.Draw(It.IsAny<PositionalVector2>(), testBattleStar.MockShapeDrawer.Object), Times.Once);
+        testBattleStar.MockShape.Verify(s => s.Draw(It.IsAny<PositionalVector2>()), Times.Once);
     }
 
     [Fact]

--- a/BattleStars.Tests/Core/BattleStarTest.cs
+++ b/BattleStars.Tests/Core/BattleStarTest.cs
@@ -111,8 +111,6 @@ public class BattleStarTest : IClassFixture<TestBattleStarFixture>
         IShooter nullShooter = null!;
 
         Action act = () => new BattleStar(mockShape.Object, mockMovable.Object, mockDestructable.Object, nullShooter);
-
-
         // Act & Assert
         act.Should().Throw<ArgumentNullException>();
     }

--- a/BattleStars.Tests/Shapes/CircleTest.cs
+++ b/BattleStars.Tests/Shapes/CircleTest.cs
@@ -34,6 +34,7 @@ public class CircleTest
         - Test the Circle constructor with valid parameters
         - Test the Circle constructor with invalid parameters
         - Test the Circle constructor with NaN, Infinity, negative, and zero radius
+        - Test the Circle constructor with null IShapeDrawer
     */
 
     [Theory]
@@ -44,7 +45,7 @@ public class CircleTest
     {
         // Arrange
         var mockShapeDrawer = new MockShapeDrawer();
-        Action act = () => new Circle(radius, Color.Red);
+        Action act = () => new Circle(radius, Color.Red, mockShapeDrawer);
 
         // Assert
         act.Should().Throw<ArgumentException>()
@@ -59,12 +60,23 @@ public class CircleTest
     {
         // Arrange
         var mockShapeDrawer = new MockShapeDrawer();
-        Action act = () => new Circle(radius, Color.Red);
+        Action act = () => new Circle(radius, Color.Red, mockShapeDrawer);
 
         // Assert
         act.Should().Throw<ArgumentOutOfRangeException>()
             .WithMessage("radius cannot be " + expectedException + ".*")
             .And.ParamName.Should().Be("radius");
+    }
+
+    [Fact]
+    public void GivenCircle_WhenConstructedWithNullShapeDrawer_ThenThrowsArgumentNullException()
+    {
+        Action act = () => new Circle(5, Color.Red, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .WithMessage("Value cannot be null.*")
+            .And.ParamName.Should().Be("drawer");
     }
 
     #endregion
@@ -88,7 +100,7 @@ public class CircleTest
     public void GivenCircle_WhenTestingContains_ThenReturnsExpectedResult(float pointX, float pointY, bool expected)
     {
         // Arrange
-        var circle = new Circle(5.0f, Color.Red);
+        var circle = new Circle(5.0f, Color.Red, new MockShapeDrawer());
         var point = new PositionalVector2(pointX, pointY);
 
         // Act
@@ -113,33 +125,15 @@ public class CircleTest
     {
         // Arrange
         var mockShapeDrawer = new MockShapeDrawer();
-        var circle = new Circle(5.0f, Color.Red);
+        var circle = new Circle(5.0f, Color.Red, mockShapeDrawer);
         var vector = PositionalVector2.Zero;
 
         // Act
-        circle.Draw(vector, mockShapeDrawer);
+        circle.Draw(vector);
 
         // Assert
         mockShapeDrawer.DrawCalled.Should().BeTrue();
     }
 
-    [Fact]
-    public void GivenCircle_WhenDrawCalled_WithNullDrawer_ThenThrowsArgumentNullException()
-    {
-        // Arrange
-        var circle = new Circle(5.0f, Color.Red);
-        var position = PositionalVector2.Zero;
-
-        // Act
-        Action act = () => circle.Draw(position, null!);
-
-        // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithMessage("Value cannot be null.*")
-            .And.ParamName.Should().Be("drawer");
-    }
-
     #endregion
-
-
 }

--- a/BattleStars.Tests/Shapes/PolyShapeTest.cs
+++ b/BattleStars.Tests/Shapes/PolyShapeTest.cs
@@ -52,11 +52,12 @@ public class PolyShapeTest
     [Fact]
     public void GivenMalformedTriangle_WhenConstructingPolygon_ThenThrowsArgumentException()
     {
+        var mockShapeDrawer = new MockShapeDrawer();
         Action act = () => new PolyShape(
         [
-            new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red),
-            new Triangle(PositionalVector2.UnitX, new PositionalVector2(1, 1), PositionalVector2.UnitY, Color.Red),
-            new Triangle(PositionalVector2.Zero, PositionalVector2.Zero, PositionalVector2.Zero, Color.Red) // Malformed triangle
+            new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red, mockShapeDrawer),
+            new Triangle(PositionalVector2.UnitX, new PositionalVector2(1, 1), PositionalVector2.UnitY, Color.Red, mockShapeDrawer),
+            new Triangle(PositionalVector2.Zero, PositionalVector2.Zero, PositionalVector2.Zero, Color.Red, mockShapeDrawer) // Malformed triangle
         ]);
 
         act.Should().Throw<ArgumentException>();
@@ -65,7 +66,7 @@ public class PolyShapeTest
     [Fact]
     public void GivenSingleTriangle_WhenConstructingPolygon_ThenDoesNotThrowArgumentException()
     {
-        var triangle = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red);
+        var triangle = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red, new MockShapeDrawer());
         Action act = () => new PolyShape([triangle]);
 
         act.Should().NotThrow<ArgumentException>();
@@ -74,8 +75,9 @@ public class PolyShapeTest
     [Fact]
     public void GivenMultipleTriangles_WhenConstructingPolygon_ThenDoesNotThrowArgumentException()
     {
-        var t1 = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red);
-        var t2 = new Triangle(PositionalVector2.UnitX, new PositionalVector2(1, 1), PositionalVector2.UnitY, Color.Red);
+        var mockShapeDrawer = new MockShapeDrawer();
+        var t1 = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red, mockShapeDrawer);
+        var t2 = new Triangle(PositionalVector2.UnitX, new PositionalVector2(1, 1), PositionalVector2.UnitY, Color.Red, mockShapeDrawer);
         Action act = () => new PolyShape([t1, t2]);
 
         act.Should().NotThrow<ArgumentException>();
@@ -105,8 +107,9 @@ public class PolyShapeTest
     [InlineData(0.8f,  0.8f, false)] // Inside bounding box but outside triangles
     public void GivenPolygon_WhenTestingContains_ThenReturnsExpected(float pointX, float pointY, bool expected)
     {
-        var t1 = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red);
-        var t2 = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, -PositionalVector2.UnitY, Color.Red);
+        var mockShapeDrawer = new MockShapeDrawer();
+        var t1 = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red, mockShapeDrawer);
+        var t2 = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, -PositionalVector2.UnitY, Color.Red, mockShapeDrawer);
         var poly = new PolyShape([t1, t2]);
         var point = new PositionalVector2(pointX, pointY);
 
@@ -127,30 +130,15 @@ public class PolyShapeTest
     public void GivenPolygon_WhenDrawCalled_ThenDrawerIsCalledForEachTriangle()
     {
         var drawer = new MockShapeDrawer();
-        var t1 = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red);
-        var t2 = new Triangle(PositionalVector2.UnitX, new PositionalVector2(1, 1), PositionalVector2.UnitY, Color.Red);
+        var t1 = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red, drawer);
+        var t2 = new Triangle(PositionalVector2.UnitX, new PositionalVector2(1, 1), PositionalVector2.UnitY, Color.Red, drawer);
         var poly = new PolyShape([t1, t2]);
 
-        poly.Draw(new PositionalVector2(1, 1), drawer);
+        poly.Draw(new PositionalVector2(1, 1));
         var TimesCalled = drawer.TimesCalled;
 
         drawer.DrawCalled.Should().BeTrue();
         TimesCalled.Should().Be(2);
     }
-
-    [Fact]
-    public void GivenPolygon_WhenDrawCalled_WithNullDrawer_ThenThrowsArgumentNullException()
-    {
-        var t1 = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red);
-        var t2 = new Triangle(PositionalVector2.UnitX, new PositionalVector2(1, 1), PositionalVector2.UnitY, Color.Red);
-        var poly = new PolyShape([t1, t2]);
-        var position = new PositionalVector2(1, 1);
-
-        Action act = () => poly.Draw(position, null!);
-
-        act.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("drawer");
-    }
-
     #endregion
 }

--- a/BattleStars.Tests/Shapes/RectangleTest.cs
+++ b/BattleStars.Tests/Shapes/RectangleTest.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Numerics;
 using FluentAssertions;
 using BattleStars.Utility;
+using Moq;
 
 namespace BattleStars.Tests.Shapes;
 
@@ -36,7 +37,8 @@ public class RectangleTest
     {
         var v1 = new PositionalVector2(v1x, v1y);
         var v2 = new PositionalVector2(v2x, v2y);
-        Action act = () => new BattleStars.Shapes.Rectangle(v1, v2, Color.Red);
+        var drawerMock = new MockShapeDrawer();
+        Action act = () => new BattleStars.Shapes.Rectangle(v1, v2, Color.Red, drawerMock);
 
         act.Should().Throw<ArgumentException>()
             .WithMessage("Rectangle must have non-zero width and height.*");
@@ -48,11 +50,22 @@ public class RectangleTest
         var v1 = PositionalVector2.Zero;
         var v2 = new PositionalVector2(2, 3);
         var color = Color.Blue;
-        var rect = new BattleStars.Shapes.Rectangle(v1, v2, color);
+        var drawerMock = new MockShapeDrawer();
+        var rect = new BattleStars.Shapes.Rectangle(v1, v2, color, drawerMock);
 
         rect.BoundingBox.TopLeft.Should().Be(PositionalVector2.Zero);
         rect.BoundingBox.BottomRight.Should().Be(new PositionalVector2(2, 3));
         rect.Color.Should().Be(color);
+    }
+
+    [Fact]
+    public void GivenNullDrawer_WhenConstructing_ThenThrowsNullArgumentException()
+    {
+        var v1 = new PositionalVector2(1, 0);
+        var v2 = new PositionalVector2(0, 1);
+        Action act = () => new BattleStars.Shapes.Rectangle(v1, v2, Color.Red, null!);
+
+        act.Should().Throw<ArgumentNullException>();
     }
 
     #endregion
@@ -79,7 +92,8 @@ public class RectangleTest
     {
         var vec1 = new PositionalVector2(-1, -1);
         var vec2 = new PositionalVector2(1, 1);
-        var rect = new BattleStars.Shapes.Rectangle(vec1, vec2, Color.Red);
+        var drawerMock = new MockShapeDrawer();
+        var rect = new BattleStars.Shapes.Rectangle(vec1, vec2, Color.Red, drawerMock);
         var point = new PositionalVector2(pointX, pointY);
 
         rect.Contains(point).Should().Be(expected);
@@ -98,22 +112,10 @@ public class RectangleTest
     public void GivenRectangle_WhenDrawCalled_ThenDrawerIsCalled()
     {
         var drawer = new MockShapeDrawer();
-        var rect = new BattleStars.Shapes.Rectangle(PositionalVector2.Zero, new PositionalVector2(2, 2), Color.Red);
-        rect.Draw(new PositionalVector2(1, 1), drawer);
+        var rect = new BattleStars.Shapes.Rectangle(PositionalVector2.Zero, new PositionalVector2(2, 2), Color.Red, drawer);
+        rect.Draw(new PositionalVector2(1, 1));
 
         drawer.DrawCalled.Should().BeTrue();
-    }
-
-    [Fact]
-    public void GivenRectangle_WhenDrawCalled_WithNullDrawer_ThenThrowsArgumentNullException()
-    {
-        var rect = new BattleStars.Shapes.Rectangle(PositionalVector2.Zero, new PositionalVector2(2, 2), Color.Red);
-        var position = new PositionalVector2(1, 1);
-
-        Action act = () => rect.Draw(position, null!);
-
-        act.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("drawer");
     }
 
     #endregion

--- a/BattleStars.Tests/Shapes/RectangleTest.cs
+++ b/BattleStars.Tests/Shapes/RectangleTest.cs
@@ -3,8 +3,6 @@ using System.Drawing;
 using System.Numerics;
 using FluentAssertions;
 using BattleStars.Utility;
-using Moq;
-
 namespace BattleStars.Tests.Shapes;
 
 public class RectangleTest

--- a/BattleStars.Tests/Shapes/TriangleTest.cs
+++ b/BattleStars.Tests/Shapes/TriangleTest.cs
@@ -39,7 +39,8 @@ public class TriangleTest
         var Point1 = new PositionalVector2(Point1x, Point1y);
         var Point2 = new PositionalVector2(Point2x, Point2y);
         var Point3 = new PositionalVector2(Point3x, Point3y);
-        Action act = () => new Triangle(Point1, Point2, Point3, Color.Red);
+        var drawerMock = new MockShapeDrawer();
+        Action act = () => new Triangle(Point1, Point2, Point3, Color.Red, drawerMock);
 
         act.Should().Throw<ArgumentException>()
             .WithMessage("The points do not form a valid triangle.*");
@@ -52,12 +53,25 @@ public class TriangleTest
         var Point2 = PositionalVector2.UnitX;
         var Point3 = PositionalVector2.UnitY;
         var color = Color.Blue;
-        var tri = new Triangle(Point1, Point2, Point3, color);
+        var drawerMock = new MockShapeDrawer();
+        var tri = new Triangle(Point1, Point2, Point3, color, drawerMock);
 
         tri.Point1.Should().Be(Point1);
         tri.Point2.Should().Be(Point2);
         tri.Point3.Should().Be(Point3);
         tri.Color.Should().Be(color);
+    }
+
+    [Fact]
+    public void GivenNullDrawer_WhenConstructing_ThenThrowsNullArgumentException()
+    {
+        var Point1 = new PositionalVector2(1, 0);
+        var Point2 = new PositionalVector2(0, 1);
+        var Point3 = new PositionalVector2(0, 0);
+        Action act = () => new Triangle(Point1, Point2, Point3, Color.Red, null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithMessage("*drawer*");
     }
 
     #endregion
@@ -83,7 +97,8 @@ public class TriangleTest
         var Point1 = PositionalVector2.Zero;
         var Point2 = PositionalVector2.UnitX;
         var Point3 = PositionalVector2.UnitY;
-        var tri = new Triangle(Point1, Point2, Point3, Color.Red);
+        var drawerMock = new MockShapeDrawer();
+        var tri = new Triangle(Point1, Point2, Point3, Color.Red, drawerMock);
         var point = new PositionalVector2(pointX, pointY);
 
         tri.Contains(point).Should().Be(expected);
@@ -102,22 +117,10 @@ public class TriangleTest
     public void GivenTriangle_WhenDrawCalled_ThenDrawerIsCalled()
     {
         var drawer = new MockShapeDrawer();
-        var tri = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red);
-        tri.Draw(new PositionalVector2(1, 1), drawer);
+        var tri = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red, drawer);
+        tri.Draw(new PositionalVector2(1, 1));
 
         drawer.DrawCalled.Should().BeTrue();
-    }
-
-    [Fact]
-    public void GivenTriangle_WhenDrawCalled_WithNullDrawer_ThenThrowsArgumentNullException()
-    {
-        var tri = new Triangle(PositionalVector2.Zero, PositionalVector2.UnitX, PositionalVector2.UnitY, Color.Red);
-        var position = new PositionalVector2(1, 1);
-
-        Action act = () => tri.Draw(position, null!);
-
-        act.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("drawer");
     }
 
     #endregion

--- a/BattleStars/Core/BattleStar.cs
+++ b/BattleStars/Core/BattleStar.cs
@@ -8,27 +8,24 @@ namespace BattleStars.Core;
 public class BattleStar : IBattleStar
 {
     private readonly IShape _shape;
-    private readonly IShapeDrawer _shapeDrawer;
     private readonly IMovable _movable;
     private readonly IDestructable _destructable;
     private readonly IShooter _shooter;
 
-    public BattleStar(IShape shape, IShapeDrawer shapeDrawer, IMovable movable, IDestructable destructable, IShooter shooter)
+    public BattleStar(IShape shape, IMovable movable, IDestructable destructable, IShooter shooter)
     {
         ArgumentNullException.ThrowIfNull(shape, nameof(shape));
-        ArgumentNullException.ThrowIfNull(shapeDrawer, nameof(shapeDrawer));
         ArgumentNullException.ThrowIfNull(movable, nameof(movable));
         ArgumentNullException.ThrowIfNull(destructable, nameof(destructable));
         ArgumentNullException.ThrowIfNull(shooter, nameof(shooter));
 
         _shape = shape;
-        _shapeDrawer = shapeDrawer;
         _movable = movable;
         _destructable = destructable;
         _shooter = shooter;
     }
 
-    public void Draw() => _shape.Draw(_movable.Position, _shapeDrawer);
+    public void Draw() => _shape.Draw(_movable.Position);
 
     public BoundingBox GetBoundingBox() => _shape.BoundingBox;
 

--- a/BattleStars/Program.cs
+++ b/BattleStars/Program.cs
@@ -14,7 +14,7 @@ var drawer = new RaylibShapeDrawer();
 var boundaryChecker = new BoundaryChecker(0 + 25, 800 - 25, 0 + 25, 600 - 25); // 50 is the player size
 
 // Create a shape factory
-var shapeFactory = new ShapeFactory();
+var shapeFactory = new ShapeFactory(drawer);
 
 
 // Create player BattleStar
@@ -33,7 +33,6 @@ var playerShooter = new BasicShooter(ShotFactory.CreateLaserShot, DirectionalVec
 
 var playerBattleStar = new BattleStar(
     playershape,
-    drawer,
     playerMovable,
     playerDestructable,
     playerShooter
@@ -63,7 +62,6 @@ for (int i = 0; i < enemyCount; i++)
 
     var enemyBattleStar = new BattleStar(
         enemyShape,
-        drawer,
         enemyMovable,
         enemyDestructable,
         enemyShooter

--- a/BattleStars/Shapes/Circle.cs
+++ b/BattleStars/Shapes/Circle.cs
@@ -8,9 +8,11 @@ public class Circle : IShape
     private readonly float _radius;
     private readonly Color _color;
     public BoundingBox BoundingBox { get; }
+    private readonly IShapeDrawer _drawer;
 
-    public Circle(float radius, Color color)
+    public Circle(float radius, Color color, IShapeDrawer drawer)
     {
+        ArgumentNullException.ThrowIfNull(drawer);
         FloatValidator.ThrowIfNaNOrInfinity(radius, nameof(radius));
         FloatValidator.ThrowIfNegative(radius, nameof(radius));
         FloatValidator.ThrowIfZero(radius, nameof(radius));
@@ -18,6 +20,7 @@ public class Circle : IShape
         _radius = radius;
         _color = color;
         BoundingBox = new BoundingBox(new PositionalVector2(-_radius, -_radius), new PositionalVector2(_radius, _radius));
+        _drawer = drawer;
     }
 
     public bool Contains(PositionalVector2 point)
@@ -26,10 +29,8 @@ public class Circle : IShape
         return point.Position.LengthSquared() <= _radius * _radius;
     }
 
-    public void Draw(PositionalVector2 position, IShapeDrawer drawer)
+    public void Draw(PositionalVector2 position)
     {
-        ArgumentNullException.ThrowIfNull(drawer);
-
-        drawer.DrawCircle(position, _radius, _color);
+        _drawer.DrawCircle(position, _radius, _color);
     }
 }

--- a/BattleStars/Shapes/IShape.cs
+++ b/BattleStars/Shapes/IShape.cs
@@ -6,5 +6,5 @@ public interface IShape : IContains<PositionalVector2>
 {
     BoundingBox BoundingBox { get; }
 
-    void Draw(PositionalVector2 position, IShapeDrawer drawer);
+    void Draw(PositionalVector2 position);
 }

--- a/BattleStars/Shapes/PolyShape.cs
+++ b/BattleStars/Shapes/PolyShape.cs
@@ -5,7 +5,7 @@ namespace BattleStars.Shapes;
 public class PolyShape : IShape
 {
     private readonly IShape[] _shapes;
-    public BoundingBox BoundingBox { get; } 
+    public BoundingBox BoundingBox { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PolyShape"/> class with the specified triangles
@@ -59,12 +59,11 @@ public class PolyShape : IShape
         return false;
     }
 
-    public void Draw(PositionalVector2 entityPosition, IShapeDrawer drawer)
+    public void Draw(PositionalVector2 entityPosition)
     {
-        ArgumentNullException.ThrowIfNull(drawer);
         foreach (var shape in _shapes)
         {
-            shape.Draw(entityPosition, drawer);
+            shape.Draw(entityPosition);
         }
     }
 

--- a/BattleStars/Shapes/Rectangle.cs
+++ b/BattleStars/Shapes/Rectangle.cs
@@ -6,8 +6,8 @@ namespace BattleStars.Shapes;
 public class Rectangle : IShape
 {
     public Color Color { get; private set; }
-
     public BoundingBox BoundingBox { get; }
+    private readonly IShapeDrawer _drawer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Rectangle"/> class with the specified top-left and bottom-right corners.
@@ -17,9 +17,9 @@ public class Rectangle : IShape
     /// </summary>
     /// <param name="v1"></param>
     /// <param name="v2"></param>
-    public Rectangle(PositionalVector2 v1, PositionalVector2 v2, Color color)
+    public Rectangle(PositionalVector2 v1, PositionalVector2 v2, Color color, IShapeDrawer drawer)
     {
-
+        ArgumentNullException.ThrowIfNull(drawer);
         float minX = Math.Min(v1.X, v2.X);
         float minY = Math.Min(v1.Y, v2.Y);
         float maxX = Math.Max(v1.X, v2.X);
@@ -30,6 +30,7 @@ public class Rectangle : IShape
 
         BoundingBox = new BoundingBox(new PositionalVector2(minX, minY), new PositionalVector2(maxX, maxY));
         Color = color;
+        _drawer = drawer;
     }
 
     public bool Contains(PositionalVector2 point)
@@ -37,9 +38,8 @@ public class Rectangle : IShape
         return BoundingBox.Contains(point);
     }
 
-    public void Draw(PositionalVector2 position, IShapeDrawer drawer)
+    public void Draw(PositionalVector2 position)
     {
-        ArgumentNullException.ThrowIfNull(drawer);
-        drawer.DrawRectangle(position + BoundingBox.TopLeft, position + BoundingBox.BottomRight, Color);
+        _drawer.DrawRectangle(position + BoundingBox.TopLeft, position + BoundingBox.BottomRight, Color);
     }
 }

--- a/BattleStars/Shapes/ShapeFactory.cs
+++ b/BattleStars/Shapes/ShapeFactory.cs
@@ -12,7 +12,7 @@ public class ShapeFactory
 
     public ShapeFactory(IShapeDrawer drawer)
     {
-        ArgumentNullException.ThrowIfNull(drawer, nameof(drawer));
+        ArgumentNullException.ThrowIfNull(drawer);
         _drawer = drawer;
     }
 

--- a/BattleStars/Shapes/ShapeFactory.cs
+++ b/BattleStars/Shapes/ShapeFactory.cs
@@ -8,6 +8,13 @@ public class ShapeFactory
     private readonly float _defaultSize = 1.0f; // Default size for shapes
     private Color _color;
     private float _scale;
+    private IShapeDrawer _drawer;
+
+    public ShapeFactory(IShapeDrawer drawer)
+    {
+        ArgumentNullException.ThrowIfNull(drawer, nameof(drawer));
+        _drawer = drawer;
+    }
 
     public IShape CreateShape(ShapeDescriptor shapeDescriptor)
     {
@@ -32,7 +39,7 @@ public class ShapeFactory
 
     private Circle CreateCircle()
     {
-        return new Circle(_scale * _defaultSize, _color);
+        return new Circle(_scale * _defaultSize, _color, _drawer);
     }
 
     private Rectangle CreateSquare()
@@ -40,7 +47,7 @@ public class ShapeFactory
         float halfSize = _scale * _defaultSize / 2;
         PositionalVector2 topLeft = new(-halfSize, -halfSize);
         PositionalVector2 bottomRight = new(halfSize, halfSize);
-        return new Rectangle(topLeft, bottomRight, _color);
+        return new Rectangle(topLeft, bottomRight, _color, _drawer);
     }
 
     private Triangle CreateTriangle()
@@ -53,7 +60,7 @@ public class ShapeFactory
         PositionalVector2 point2 = new(halfSize, height / 3f);
         PositionalVector2 point3 = new(0, -2f * height / 3f);
 
-        return new Triangle(point1, point2, point3, _color);
+        return new Triangle(point1, point2, point3, _color, _drawer);
     }
 
     private PolyShape CreateHexagon()
@@ -76,7 +83,7 @@ public class ShapeFactory
             PositionalVector2 p1 = PositionalVector2.Zero;
             PositionalVector2 p2 = outerPoints[i];
             PositionalVector2 p3 = outerPoints[(i + 1) % 6];
-            triangles[i] = new Triangle(p1, p2, p3, _color);
+            triangles[i] = new Triangle(p1, p2, p3, _color, _drawer);
         }
 
         return new PolyShape(triangles);

--- a/BattleStars/Shapes/Triangle.cs
+++ b/BattleStars/Shapes/Triangle.cs
@@ -11,6 +11,7 @@ public class Triangle : IShape
     public PositionalVector2 Point3 { get; private set; }
     public BoundingBox BoundingBox { get; }
     public Color Color { get; private set; }
+    private readonly IShapeDrawer _drawer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Triangle"/> class with the specified points.
@@ -21,8 +22,9 @@ public class Triangle : IShape
     /// <param name="point1">The first point of the triangle.</param>
     /// <param name="point2">The second point of the triangle.</param>
     /// <param name="point3">The third point of the triangle.</param>
-    public Triangle(PositionalVector2 point1, PositionalVector2 point2, PositionalVector2 point3, Color color)
+    public Triangle(PositionalVector2 point1, PositionalVector2 point2, PositionalVector2 point3, Color color, IShapeDrawer drawer)
     {
+        ArgumentNullException.ThrowIfNull(drawer);
         Point1 = point1;
         Point2 = point2;
         Point3 = point3;
@@ -32,6 +34,7 @@ public class Triangle : IShape
 
         Color = color;
         BoundingBox = CalculateBoundingBox();
+        _drawer = drawer;
     }
 
     private BoundingBox CalculateBoundingBox()
@@ -81,9 +84,8 @@ public class Triangle : IShape
         return (u >= 0) && (v >= 0) && (u + v <= 1);
     }
 
-    public void Draw(PositionalVector2 entityPosition, IShapeDrawer drawer)
+    public void Draw(PositionalVector2 entityPosition)
     {
-        ArgumentNullException.ThrowIfNull(drawer);
-        drawer.DrawTriangle(entityPosition + Point1, entityPosition + Point2, entityPosition + Point3, Color);
+        _drawer.DrawTriangle(entityPosition + Point1, entityPosition + Point2, entityPosition + Point3, Color);
     }
 }


### PR DESCRIPTION
## Summary

This PR removes the need to pass `IShapeDrawer` to `IShape.Draw()` by injecting it directly into shape constructors. All shapes now hold a reference to their drawer, simplifying draw calls and improving consistency.

## Motivation

- ✅ Reduces boilerplate by eliminating repeated drawer injection at draw time
- ✅ Improves clarity: shapes now encapsulate their rendering logic more cleanly
- ✅ Enhances testability: constructor-based injection allows for better mocking and validation
- ✅ Enforces single-responsibility: shapes are now responsible for their own drawing behavior

## Changes

- Removed `IShapeDrawer` parameter from `IShape.Draw()`
- Updated all shape implementations (`Circle`, `Rectangle`, `Triangle`, `PolyShape`) to accept drawer in constructor
- Updated `ShapeFactory` to inject drawer during shape creation
- Modified `BattleStar` to reflect new shape API
- Updated all affected tests to use constructor-based drawer injection
- Added null-check tests for drawer injection to ensure robustness

## Impact

- Breaking change: affects all consumers of `IShape.Draw()`
- Improves architectural consistency and paves the way for future rendering enhancements

## Related

Builds on centralized validation and compositional design introduced in earlier PRs.