### PR TITLE
breaking: refactor ShapeDescriptor to centralize validation and enfor…

### DIFF
--- a/BattleStars.Tests/Shapes/ShapeDescriptorTest.cs
+++ b/BattleStars.Tests/Shapes/ShapeDescriptorTest.cs
@@ -1,0 +1,47 @@
+using System.Drawing;
+using FluentAssertions;
+using BattleStars.Shapes;
+
+namespace BattleStars.Tests.Shapes;
+
+public class ShapeDescriptorTest
+{
+    [Theory]
+    [InlineData(ShapeType.Hexagon)]
+    [InlineData(ShapeType.Circle)]
+    [InlineData(ShapeType.Triangle)]
+    [InlineData(ShapeType.Square)]
+    public void GivenValidParameters_WhenConstructed_ThenPropertiesAreSet(ShapeType shapeType)
+    {
+        // Given
+        var scale = 2.5f;
+        var color = Color.Blue;
+
+        // When
+        var desc = new ShapeDescriptor(shapeType, scale, color);
+
+        // Then
+        desc.ShapeType.Should().Be(shapeType);
+        desc.Scale.Should().Be(scale);
+        desc.Color.Should().Be(color);
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-1f)]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(float.NegativeInfinity)]
+    public void GivenInvalidScale_WhenConstructed_ThenThrowsArgumentException(float invalidScale)
+    {
+        // Given
+        var shapeType = ShapeType.Circle;
+        var color = Color.Red;
+
+        // When
+        Action act = () => new ShapeDescriptor(shapeType, invalidScale, color);
+
+        // Then
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/BattleStars/Program.cs
+++ b/BattleStars/Program.cs
@@ -18,12 +18,7 @@ var shapeFactory = new ShapeFactory(drawer);
 
 
 // Create player BattleStar
-var playershape = shapeFactory.CreateShape(new ShapeDescriptor
-{
-    ShapeType = ShapeType.Square,
-    Scale = 50.0f,
-    Color = System.Drawing.Color.Blue
-});
+var playershape = shapeFactory.CreateShape(new ShapeDescriptor(ShapeType.Square, 50.0f, System.Drawing.Color.Blue));
 
 var playerMovable = new PlayerMovable(new PositionalVector2(100, 100), 5f, boundaryChecker);
 
@@ -45,12 +40,7 @@ int enemyCount = 5;
 
 for (int i = 0; i < enemyCount; i++)
 {
-    var enemyShape = shapeFactory.CreateShape(new ShapeDescriptor
-    {
-        ShapeType = ShapeType.Circle,
-        Scale = 30.0f,
-        Color = System.Drawing.Color.Red
-    });
+    var enemyShape = shapeFactory.CreateShape(new ShapeDescriptor(ShapeType.Circle, 30.0f, System.Drawing.Color.Red));
 
     var enemyPosition = new PositionalVector2(700, i * 100 + 50);
     var enemyDirection = -DirectionalVector2.UnitX;

--- a/BattleStars/Shapes/ShapeDescriptor.cs
+++ b/BattleStars/Shapes/ShapeDescriptor.cs
@@ -1,4 +1,5 @@
 using System.Drawing;
+using BattleStars.Utility;
 namespace BattleStars.Shapes;
 
 public enum ShapeType
@@ -11,7 +12,16 @@ public enum ShapeType
 
 public class ShapeDescriptor
 {
-    public ShapeType ShapeType { get; set; }
-    public float Scale { get; set; }
-    public Color Color { get; set; }
+    public ShapeType ShapeType { get; }
+    public float Scale { get; }
+    public Color Color { get; }
+
+    public ShapeDescriptor(ShapeType shapeType, float scale, Color color)
+    {
+        FloatValidator.ThrowIfNaNOrInfinity(scale, nameof(scale));
+        FloatValidator.ThrowIfNegativeOrZero(scale, nameof(scale));
+        ShapeType = shapeType;
+        Scale = scale;
+        Color = color;
+    }
 }

--- a/BattleStars/Shapes/ShapeFactory.cs
+++ b/BattleStars/Shapes/ShapeFactory.cs
@@ -19,9 +19,6 @@ public class ShapeFactory
     public IShape CreateShape(ShapeDescriptor shapeDescriptor)
     {
         ArgumentNullException.ThrowIfNull(shapeDescriptor, nameof(shapeDescriptor));
-        FloatValidator.ThrowIfNaNOrInfinity(shapeDescriptor.Scale, nameof(shapeDescriptor.Scale));
-        FloatValidator.ThrowIfNegative(shapeDescriptor.Scale, nameof(shapeDescriptor.Scale));
-        FloatValidator.ThrowIfZero(shapeDescriptor.Scale, nameof(shapeDescriptor.Scale));
 
         _color = shapeDescriptor.Color;
         _scale = shapeDescriptor.Scale;


### PR DESCRIPTION
…ce immutability

ShapeDescriptor now uses a constructor to enforce valid initialization. All properties are read-only, preventing mutation after creation. Files dependent on ShapeDescriptor has been updated to reflect changes. New test class ShapeDescriptorTest now adds unit tests validating behavior.

This change centralizes validation logic, reducing boilerplate in dependent classes. It also improves code clarity and correctness by ensuring shape descriptors are immutable and consistently valid.