### PR TITLE
8 add tests for raylibshapedrawer

### DIFF
--- a/BattleStars.Tests/Shapes/RaylibShapeDrawerTest.cs
+++ b/BattleStars.Tests/Shapes/RaylibShapeDrawerTest.cs
@@ -3,94 +3,93 @@ using BattleStars.Shapes;
 using BattleStars.Utility;
 using FluentAssertions;
 
-namespace BattleStars.Tests.Shapes
+namespace BattleStars.Tests.Shapes;
+public class RaylibShapeDrawerTests
 {
-    public class RaylibShapeDrawerTests
+    private class LoggingGraphics : IRaylibGraphics
     {
-        private class LoggingGraphics : IRaylibGraphics
-        {
-            public List<string> Calls { get; } = new();
+        public List<string> Calls { get; } = new();
 
-            public void DrawRectangle(PositionalVector2 topLeft, PositionalVector2 bottomRight, Color color) =>
-                Calls.Add($"Rectangle: {topLeft}, {bottomRight}, {color}");
+        public void DrawRectangle(PositionalVector2 topLeft, PositionalVector2 size, Color color) =>
+            Calls.Add($"Rectangle: {topLeft}, {size}, {color}");
 
-            public void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, Color color) =>
-                Calls.Add($"Triangle: {p1}, {p2}, {p3}, {color}");
+        public void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, Color color) =>
+            Calls.Add($"Triangle: {p1}, {p2}, {p3}, {color}");
 
-            public void DrawCircle(PositionalVector2 center, float radius, Color color) =>
-                Calls.Add($"Circle: {center}, {radius}, {color}");
-        }
-
-        [Fact]
-        public void GivenNullIRaylibGraphics_WhenConstructed_ThenThrowsNullException()
-        {
-            Action act = () => _ = new RaylibShapeDrawer(null!);
-            act.Should().Throw<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void GivenRectangle_WhenDrawn_ThenGraphicsReceivesCorrectCall()
-        {
-            // Arrange
-            var logger = new LoggingGraphics();
-            var drawer = new RaylibShapeDrawer(logger);
-            var topLeft = new PositionalVector2(10, 20);
-            var bottomRight = new PositionalVector2(30, 40);
-            var color = Color.Red;
-
-            // Act
-            drawer.DrawRectangle(topLeft, bottomRight, color);
-
-            // Assert
-            logger.Calls.Should().ContainSingle()
-                .Which.Should().StartWith("Rectangle:")
-                .And.Contain($"{topLeft}")
-                .And.Contain($"{bottomRight}")
-                .And.Contain($"{color}");
-        }
-
-        [Fact]
-        public void GivenTriangle_WhenDrawn_ThenGraphicsReceivesCorrectCall()
-        {
-            // Arrange
-            var logger = new LoggingGraphics();
-            var drawer = new RaylibShapeDrawer(logger);
-            var p1 = new PositionalVector2(0, 0);
-            var p2 = new PositionalVector2(10, 0);
-            var p3 = new PositionalVector2(5, 10);
-            var color = Color.Blue;
-
-            // Act
-            drawer.DrawTriangle(p1, p2, p3, color);
-
-            // Assert
-            logger.Calls.Should().ContainSingle()
-                .Which.Should().StartWith("Triangle:")
-                .And.Contain($"{p1}")
-                .And.Contain($"{p2}")
-                .And.Contain($"{p3}")
-                .And.Contain($"{color}");
-        }
-
-        [Fact]
-        public void GivenCircle_WhenDrawn_ThenGraphicsReceivesCorrectCall()
-        {
-            // Arrange
-            var logger = new LoggingGraphics();
-            var drawer = new RaylibShapeDrawer(logger);
-            var center = new PositionalVector2(50, 50);
-            var radius = 25f;
-            var color = Color.Green;
-
-            // Act
-            drawer.DrawCircle(center, radius, color);
-
-            // Assert
-            logger.Calls.Should().ContainSingle()
-                .Which.Should().StartWith("Circle:")
-                .And.Contain($"{center}")
-                .And.Contain($"{radius}")
-                .And.Contain($"{color}");
-        }
+        public void DrawCircle(PositionalVector2 center, float radius, Color color) =>
+            Calls.Add($"Circle: {center}, {radius}, {color}");
     }
+
+    [Fact]
+    public void GivenNullIRaylibGraphics_WhenConstructed_ThenThrowsNullException()
+    {
+        Action act = () => _ = new RaylibShapeDrawer(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GivenRectangle_WhenDrawn_ThenGraphicsReceivesCorrectCall()
+    {
+        // Arrange
+        var logger = new LoggingGraphics();
+        var drawer = new RaylibShapeDrawer(logger);
+        var topLeft = new PositionalVector2(-10, -20);
+        var bottomRight = new PositionalVector2(30, 40);
+        var expectedSize = bottomRight-topLeft;
+        var color = Color.Red;
+
+        // Act
+        drawer.DrawRectangle(topLeft, bottomRight, color);
+
+        // Assert
+        logger.Calls.Should().ContainSingle()
+            .Which.Should().StartWith("Rectangle:")
+            .And.Contain($"{topLeft}")
+            .And.Contain($"{expectedSize}")
+            .And.Contain($"{color}");
+    }
+
+    [Fact]
+    public void GivenTriangle_WhenDrawn_ThenGraphicsReceivesCorrectCall()
+    {
+        // Arrange
+        var logger = new LoggingGraphics();
+        var drawer = new RaylibShapeDrawer(logger);
+        var p1 = new PositionalVector2(0, 0);
+        var p2 = new PositionalVector2(10, 0);
+        var p3 = new PositionalVector2(5, 10);
+        var color = Color.Blue;
+
+        // Act
+        drawer.DrawTriangle(p1, p2, p3, color);
+
+        // Assert
+        logger.Calls.Should().ContainSingle()
+            .Which.Should().StartWith("Triangle:")
+            .And.Contain($"{p1}")
+            .And.Contain($"{p2}")
+            .And.Contain($"{p3}")
+            .And.Contain($"{color}");
+    }
+    [Fact]
+    public void GivenCircle_WhenDrawn_ThenGraphicsReceivesCorrectCall()
+    {
+        // Arrange
+        var logger = new LoggingGraphics();
+        var drawer = new RaylibShapeDrawer(logger);
+        var center = new PositionalVector2(50, 50);
+        var radius = 25f;
+        var color = Color.Green;
+
+        // Act
+        drawer.DrawCircle(center, radius, color);
+
+        // Assert
+        logger.Calls.Should().ContainSingle()
+            .Which.Should().StartWith("Circle:")
+            .And.Contain($"{center}")
+            .And.Contain($"{radius}")
+            .And.Contain($"{color}");
+    }
+
 }

--- a/BattleStars.Tests/Shapes/RaylibShapeDrawerTest.cs
+++ b/BattleStars.Tests/Shapes/RaylibShapeDrawerTest.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Drawing;
+using BattleStars.Shapes;
+using BattleStars.Utility;
+using FluentAssertions;
+using Xunit;
+
+namespace BattleStars.Tests.Shapes
+{
+    public class RaylibShapeDrawerTests
+    {
+        private class LoggingGraphics : IRaylibGraphics
+        {
+            public List<string> Calls { get; } = new();
+
+            public void DrawRectangle(PositionalVector2 topLeft, PositionalVector2 bottomRight, Color color) =>
+                Calls.Add($"Rectangle: {topLeft}, {bottomRight}, {color}");
+
+            public void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, Color color) =>
+                Calls.Add($"Triangle: {p1}, {p2}, {p3}, {color}");
+
+            public void DrawCircle(PositionalVector2 center, float radius, Color color) =>
+                Calls.Add($"Circle: {center}, {radius}, {color}");
+        }
+
+        [Fact]
+        public void GivenNullIRaylibGraphics_WhenConstructed_ThenThrowsNullException()
+        {
+            Action act = () => _ = new RaylibShapeDrawer(null!);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GivenRectangle_WhenDrawn_ThenGraphicsReceivesCorrectCall()
+        {
+            // Arrange
+            var logger = new LoggingGraphics();
+            var drawer = new RaylibShapeDrawer(logger);
+            var topLeft = new PositionalVector2(10, 20);
+            var bottomRight = new PositionalVector2(30, 40);
+            var color = Color.Red;
+
+            // Act
+            drawer.DrawRectangle(topLeft, bottomRight, color);
+
+            // Assert
+            logger.Calls.Should().ContainSingle()
+                .Which.Should().StartWith("Rectangle:")
+                .And.Contain($"{topLeft}")
+                .And.Contain($"{bottomRight}")
+                .And.Contain($"{color}");
+        }
+
+        [Fact]
+        public void GivenTriangle_WhenDrawn_ThenGraphicsReceivesCorrectCall()
+        {
+            // Arrange
+            var logger = new LoggingGraphics();
+            var drawer = new RaylibShapeDrawer(logger);
+            var p1 = new PositionalVector2(0, 0);
+            var p2 = new PositionalVector2(10, 0);
+            var p3 = new PositionalVector2(5, 10);
+            var color = Color.Blue;
+
+            // Act
+            drawer.DrawTriangle(p1, p2, p3, color);
+
+            // Assert
+            logger.Calls.Should().ContainSingle()
+                .Which.Should().StartWith("Triangle:")
+                .And.Contain($"{p1}")
+                .And.Contain($"{p2}")
+                .And.Contain($"{p3}")
+                .And.Contain($"{color}");
+        }
+
+        [Fact]
+        public void GivenCircle_WhenDrawn_ThenGraphicsReceivesCorrectCall()
+        {
+            // Arrange
+            var logger = new LoggingGraphics();
+            var drawer = new RaylibShapeDrawer(logger);
+            var center = new PositionalVector2(50, 50);
+            var radius = 25f;
+            var color = Color.Green;
+
+            // Act
+            drawer.DrawCircle(center, radius, color);
+
+            // Assert
+            logger.Calls.Should().ContainSingle()
+                .Which.Should().StartWith("Circle:")
+                .And.Contain($"{center}")
+                .And.Contain($"{radius}")
+                .And.Contain($"{color}");
+        }
+    }
+}

--- a/BattleStars.Tests/Shapes/RaylibShapeDrawerTest.cs
+++ b/BattleStars.Tests/Shapes/RaylibShapeDrawerTest.cs
@@ -1,9 +1,7 @@
-using System.Collections.Generic;
 using System.Drawing;
 using BattleStars.Shapes;
 using BattleStars.Utility;
 using FluentAssertions;
-using Xunit;
 
 namespace BattleStars.Tests.Shapes
 {

--- a/BattleStars.Tests/Shapes/RaylibShapeDrawerTest.cs
+++ b/BattleStars.Tests/Shapes/RaylibShapeDrawerTest.cs
@@ -35,7 +35,7 @@ public class RaylibShapeDrawerTests
         var drawer = new RaylibShapeDrawer(logger);
         var topLeft = new PositionalVector2(-10, -20);
         var bottomRight = new PositionalVector2(30, 40);
-        var expectedSize = bottomRight-topLeft;
+        var expectedSize = bottomRight - topLeft;
         var color = Color.Red;
 
         // Act

--- a/BattleStars/Program.cs
+++ b/BattleStars/Program.cs
@@ -8,7 +8,9 @@ using BattleStars.Utility;
 
 Raylib.InitWindow(800, 600, "BattleStars - Square Test");
 Raylib.SetTargetFPS(60);
-var drawer = new RaylibShapeDrawer();
+var graphics = new RaylibGraphicsAdapter();
+var drawer = new RaylibShapeDrawer(graphics);
+
 
 // Create boundary checker for the window (player stays fully inside)
 var boundaryChecker = new BoundaryChecker(0 + 25, 800 - 25, 0 + 25, 600 - 25); // 50 is the player size

--- a/BattleStars/Shapes/IRayLibGraphics.cs
+++ b/BattleStars/Shapes/IRayLibGraphics.cs
@@ -1,4 +1,3 @@
-// IRaylibGraphics.cs
 using System.Drawing;
 using BattleStars.Utility;
 
@@ -6,7 +5,7 @@ namespace BattleStars.Shapes
 {
     public interface IRaylibGraphics
     {
-        void DrawRectangle(PositionalVector2 topLeft, PositionalVector2 bottomRight, Color color);
+        void DrawRectangle(PositionalVector2 topLeft, PositionalVector2 size, Color color);
         void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, Color color);
         void DrawCircle(PositionalVector2 center, float radius, Color color);
     }

--- a/BattleStars/Shapes/IRayLibGraphics.cs
+++ b/BattleStars/Shapes/IRayLibGraphics.cs
@@ -1,0 +1,13 @@
+// IRaylibGraphics.cs
+using System.Drawing;
+using BattleStars.Utility;
+
+namespace BattleStars.Shapes
+{
+    public interface IRaylibGraphics
+    {
+        void DrawRectangle(PositionalVector2 topLeft, PositionalVector2 bottomRight, Color color);
+        void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, Color color);
+        void DrawCircle(PositionalVector2 center, float radius, Color color);
+    }
+}

--- a/BattleStars/Shapes/RayLibGraphicsAdapter.cs
+++ b/BattleStars/Shapes/RayLibGraphicsAdapter.cs
@@ -1,0 +1,26 @@
+using BattleStars.Utility;
+using Raylib_cs;
+
+namespace BattleStars.Shapes
+{
+    public class RaylibGraphicsAdapter : IRaylibGraphics
+    {
+        private static Color ToRaylibColor(System.Drawing.Color color) =>
+            new Color(color.R, color.G, color.B, color.A);
+
+        public void DrawRectangle(PositionalVector2 topLeft, PositionalVector2 size, System.Drawing.Color color)
+        {
+            Raylib.DrawRectangleV(topLeft, size, ToRaylibColor(color));
+        }
+
+        public void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, System.Drawing.Color color)
+        {
+            Raylib.DrawTriangle(p1, p2, p3, ToRaylibColor(color));
+        }
+
+        public void DrawCircle(PositionalVector2 center, float radius, System.Drawing.Color color)
+        {
+            Raylib.DrawCircleV(center, radius, ToRaylibColor(color));
+        }
+    }
+}

--- a/BattleStars/Shapes/RaylibShapeDrawer.cs
+++ b/BattleStars/Shapes/RaylibShapeDrawer.cs
@@ -14,7 +14,8 @@ namespace BattleStars.Shapes
             _graphics = graphics;
         }
 
-        public void DrawRectangle(PositionalVector2 topleft, PositionalVector2 bottomright, Color color) {
+        public void DrawRectangle(PositionalVector2 topleft, PositionalVector2 bottomright, Color color)
+        {
             PositionalVector2 size = bottomright - topleft;
             _graphics.DrawRectangle(topleft, size, color);
         }

--- a/BattleStars/Shapes/RaylibShapeDrawer.cs
+++ b/BattleStars/Shapes/RaylibShapeDrawer.cs
@@ -14,8 +14,8 @@ namespace BattleStars.Shapes
             _graphics = graphics;
         }
 
-        public void DrawRectangle(PositionalVector2 v1, PositionalVector2 v2, Color color) =>
-            _graphics.DrawRectangle(v1, v1 - v2, color);
+        public void DrawRectangle(PositionalVector2 topleft, PositionalVector2 bottomright, Color color) =>
+            _graphics.DrawRectangle(topleft, bottomright - topleft, color);
 
         public void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, Color color) =>
             _graphics.DrawTriangle(p1, p2, p3, color);

--- a/BattleStars/Shapes/RaylibShapeDrawer.cs
+++ b/BattleStars/Shapes/RaylibShapeDrawer.cs
@@ -14,8 +14,10 @@ namespace BattleStars.Shapes
             _graphics = graphics;
         }
 
-        public void DrawRectangle(PositionalVector2 topleft, PositionalVector2 bottomright, Color color) =>
-            _graphics.DrawRectangle(topleft, bottomright - topleft, color);
+        public void DrawRectangle(PositionalVector2 topleft, PositionalVector2 bottomright, Color color) {
+            PositionalVector2 size = bottomright - topleft;
+            _graphics.DrawRectangle(topleft, size, color);
+        }
 
         public void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, Color color) =>
             _graphics.DrawTriangle(p1, p2, p3, color);

--- a/BattleStars/Shapes/RaylibShapeDrawer.cs
+++ b/BattleStars/Shapes/RaylibShapeDrawer.cs
@@ -1,26 +1,26 @@
+// RaylibShapeDrawer.cs
+using System.Drawing;
 using BattleStars.Utility;
-using Raylib_cs;
-using System.Numerics;
-namespace BattleStars.Shapes;
 
-public class RaylibShapeDrawer : IShapeDrawer
+namespace BattleStars.Shapes
 {
-
-    private static Color ToRaylibColor(System.Drawing.Color color)
-        => new(color.R, color.G, color.B, color.A);
-    public void DrawRectangle(PositionalVector2 v1, PositionalVector2 v2, System.Drawing.Color color)
+    public class RaylibShapeDrawer : IShapeDrawer
     {
-        Raylib.DrawRectangle((int)v1.X, (int)v1.Y, (int)(v2.X - v1.X), (int)(v2.Y - v1.Y), ToRaylibColor(color));
-    }
+        private readonly IRaylibGraphics _graphics;
 
-    public void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, System.Drawing.Color color)
-    {
-        Raylib.DrawTriangle(p1, p2, p3, ToRaylibColor(color));
-    }
+        public RaylibShapeDrawer(IRaylibGraphics graphics)
+        {
+            ArgumentNullException.ThrowIfNull(graphics);
+            _graphics = graphics;
+        }
 
-    public void DrawCircle(PositionalVector2 center, float radius, System.Drawing.Color color)
-    {
-        Raylib.DrawCircle((int)center.X, (int)center.Y, radius, ToRaylibColor(color));
-    }
+        public void DrawRectangle(PositionalVector2 v1, PositionalVector2 v2, Color color) =>
+            _graphics.DrawRectangle(v1, v1 - v2, color);
 
+        public void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, Color color) =>
+            _graphics.DrawTriangle(p1, p2, p3, color);
+
+        public void DrawCircle(PositionalVector2 center, float radius, Color color) =>
+            _graphics.DrawCircle(center, radius, color);
+    }
 }


### PR DESCRIPTION
## test/refac: abstract RaylibShapeDrawer from Raylib_cs for testability

### ✨ Summary

This PR introduces an abstraction layer between `RaylibShapeDrawer` and the Raylib_cs library to enable unit testing of drawing logic without invoking the actual rendering engine.

### 🔧 Changes Introduced

- **`IRaylibGraphics`**  
  Lightweight interface defining drawing operations (`DrawRectangle`, `DrawTriangle`, `DrawCircle`) using `System.Drawing.Color` and `PositionalVector2`.

- **`RaylibGraphicsAdapter`**  
  Thin adapter that delegates calls to Raylib_cs without modifying input. Converts `System.Drawing.Color` to `Raylib_cs.Color`.

- **`RaylibShapeDrawer`**  
  Refactored to depend on `IRaylibGraphics` via constructor injection. No longer calls Raylib_cs directly.

- **`RaylibShapeDrawerTests`**  
  Adds unit tests using a mock `LoggingGraphics` implementation to verify drawing behavior without rendering.

### ✅ Benefits

- Enables isolated testing of shape drawing logic
- Decouples core logic from static Raylib_cs calls
- Makes future rendering backends or headless testing easier to support
- Keeps adapter logic minimal and focused on delegation only

### 📌 Notes

- `Program.cs` updated to instantiate `RaylibGraphicsAdapter` and inject it into `RaylibShapeDrawer`
- Adapter is intentionally untested, as it contains no logic beyond delegation
