### PR TITLE
test: exclude RaylibGraphicsAdapter from coverage analysis

### DIFF
--- a/BattleStars/Shapes/RayLibGraphicsAdapter.cs
+++ b/BattleStars/Shapes/RayLibGraphicsAdapter.cs
@@ -1,26 +1,36 @@
 using BattleStars.Utility;
 using Raylib_cs;
 
-namespace BattleStars.Shapes
+namespace BattleStars.Shapes;
+
+
+/// <summary>
+/// Adapter class to bridge between BattleStars' IShapeDrawer and Raylib's drawing functions.
+/// </summary>
+/// <remarks>
+/// This adapter is intentionally thin and delegates directly to Raylib.
+/// It exists to enable testability of higher-level logic via IRaylibGraphics.
+/// Direct testing is not applicable; excluded from coverage.
+/// </remarks>
+[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+public class RaylibGraphicsAdapter : IRaylibGraphics
 {
-    public class RaylibGraphicsAdapter : IRaylibGraphics
+    private static Color ToRaylibColor(System.Drawing.Color color) =>
+        new Color(color.R, color.G, color.B, color.A);
+
+    public void DrawRectangle(PositionalVector2 topLeft, PositionalVector2 size, System.Drawing.Color color)
     {
-        private static Color ToRaylibColor(System.Drawing.Color color) =>
-            new Color(color.R, color.G, color.B, color.A);
+        Raylib.DrawRectangleV(topLeft, size, ToRaylibColor(color));
+    }
 
-        public void DrawRectangle(PositionalVector2 topLeft, PositionalVector2 size, System.Drawing.Color color)
-        {
-            Raylib.DrawRectangleV(topLeft, size, ToRaylibColor(color));
-        }
+    public void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, System.Drawing.Color color)
+    {
+        Raylib.DrawTriangle(p1, p2, p3, ToRaylibColor(color));
+    }
 
-        public void DrawTriangle(PositionalVector2 p1, PositionalVector2 p2, PositionalVector2 p3, System.Drawing.Color color)
-        {
-            Raylib.DrawTriangle(p1, p2, p3, ToRaylibColor(color));
-        }
-
-        public void DrawCircle(PositionalVector2 center, float radius, System.Drawing.Color color)
-        {
-            Raylib.DrawCircleV(center, radius, ToRaylibColor(color));
-        }
+    public void DrawCircle(PositionalVector2 center, float radius, System.Drawing.Color color)
+    {
+        Raylib.DrawCircleV(center, radius, ToRaylibColor(color));
     }
 }
+

--- a/BattleStars/Shapes/RayLibGraphicsAdapter.cs
+++ b/BattleStars/Shapes/RayLibGraphicsAdapter.cs
@@ -3,7 +3,6 @@ using Raylib_cs;
 
 namespace BattleStars.Shapes;
 
-
 /// <summary>
 /// Adapter class to bridge between BattleStars' IShapeDrawer and Raylib's drawing functions.
 /// </summary>


### PR DESCRIPTION
RaylibGraphicsAdapter is a deliberately thin adapter that bridges testable shape logic with untestable Raylib_cs rendering. Excluding it from coverage avoids misleading metrics and clarifies its role as a seam, not a logic container.